### PR TITLE
fix: use SPDX licence identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "public/main.js",
   "homepage": "./",
-  "license": "GPL v3",
+  "license": "GPL-3.0-only",
   "description": "A native launcher for Epic Games for Linux based on Legendary",
   "repository": {
     "type": "Github",


### PR DESCRIPTION
Currently, package.json uses a to my knowledge non-standard way of writing the licence name. This MR changes it to use the more standard SPDX licence identifier for the GPL 3.0. I took the liberty to assume you meant GPL 3.0 (only) and not (or later).

See https://spdx.org/licenses/ for a list of identifiers.