### PR TITLE
PKGBUILD: Creates a symbolic link of the executable to /usr/bin/heroic

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,11 +13,13 @@ depends=('fuse2' 'gawk')
 _filename=heroic-${pkgver}.pacman
 source=("$url/releases/download/${_pkgver}/${_filename}")
 noextract=("${_filename}")
-md5sums=('6b5789d399e5a1c5faf8fca64051593d')
+md5sums=('4af80f3de4a336c9c1c42cc15dbef812')
 options=(!strip)
 
 package() {
   tar -xJv -C "${pkgdir}" -f "${srcdir}/${_filename}" usr opt
+  mkdir "$pkgdir/usr/bin"
+  ln -s "$pkgdir/opt/heroic/heroic" "$pkgdir/usr/bin/heroic"
 }
 
 # vim:set ts=2 sw=2 et: syntax=sh


### PR DESCRIPTION
A small change to PKGBUILD that creates a symbolic link to be able to launch heroic from the terminal or with a launcher like dmenu. 