### PR TITLE
Changed some of the pixel measurements to clamp()s on the header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,7 +21,7 @@
   font-family: Cabin;
   font-style: normal;
   font-weight: normal;
-  font-size: 14px;
+  font-size: clamp(18px, 1vw, 25px);
   line-height: 17px;  
   color: #C1C4C3;
 }
@@ -822,7 +822,7 @@
   align-items: center;
   place-self: center;
   justify-content: space-evenly;
-  width: 140px;
+  width: auto;
 }
 
 .totalGamesText {
@@ -849,10 +849,11 @@
 
 /* The switch - the box around the slider */
 .switch {
+  margin-inline-start: clamp(10px, 0.5vw, 20px);
   position: relative;
   display: inline-block;
-  width: 22px;
-  height: 11px;
+  width: clamp(30px, 1.65vw, 40px) ;
+  height: clamp(15px, 1.5vh, 20px);
 }
 
 /* Hide default HTML checkbox */
@@ -860,6 +861,7 @@
   opacity: 0;
   width: 0;
   height: 0;
+  margin: 0 0 0 0;
 }
 
 /* The slider */
@@ -868,7 +870,7 @@
   cursor: pointer;
   top: 0;
   left: 0;
-  right: 0;
+  right: 1px;
   bottom: 0;
   background: none;
   border: 2px solid;
@@ -879,10 +881,9 @@
 .slider:before {
   position: absolute;
   content: "";
-  height: 6px;
-  width: 6px;
-  left: 2px;
-  bottom: 1px;
+  height: -webkit-fill-available;
+  width: clamp(9px, 0.5vw, 20px);
+  left: 1px;
   background-color: #DADADA;;
   -webkit-transition: .4s;
   transition: .4s;
@@ -902,11 +903,11 @@ input:focus + .slider {
 
 input:checked + .slider:before {
   background-color: #FFA800;
-  transform: translateX(9px);
+  transform: translateX(clamp(14px, 0.775vw, 20px));
 }
 
 .slider.round {
-  border-radius: 34px;
+  border-radius: 60px;
 }
 
 .slider.round:before {


### PR DESCRIPTION
I thought that the header looked a big small when I resized the window because it wasn't changing the font-size, so I set it to a clamp() on `.App .header`. I also thought the toggle switch looked a bit too small so I clamped that too.

I have some doubts about the header font size being a tad too big now, but if you change the preferred size in the clamp on `.App .header` you can make it a bit smaller easily.

How it looks currently: 
![image](https://user-images.githubusercontent.com/50517631/105047437-3b1d4180-5a62-11eb-8dc2-b400a9bd9ae6.png)
![image](https://user-images.githubusercontent.com/50517631/105047520-58521000-5a62-11eb-880a-f2e0382d0135.png)
![image](https://user-images.githubusercontent.com/50517631/105048064-08c01400-5a63-11eb-8a1a-b3ba510cbb76.png)
![image](https://user-images.githubusercontent.com/50517631/105048085-0f4e8b80-5a63-11eb-864a-e76e68f2adf7.png)


How it looks with the clamps:
![image](https://user-images.githubusercontent.com/50517631/105047563-66079580-5a62-11eb-89d9-6f3abe14df56.png)
![image](https://user-images.githubusercontent.com/50517631/105047603-6ef86700-5a62-11eb-9f6e-578cdb9175e1.png)
![image](https://user-images.githubusercontent.com/50517631/105047996-f514ad80-5a62-11eb-8b1c-2c5145adf8c5.png)
![image](https://user-images.githubusercontent.com/50517631/105047964-ec23dc00-5a62-11eb-9578-7659d1930d68.png)

