### PR TITLE
Show installed games first in the library

### DIFF
--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -34,6 +34,14 @@ export class GlobalState extends PureComponent<Props> {
   refresh = async (): Promise<void> => {
     this.setState({refreshing: true})
     const { user, library } = await getLegendaryConfig()
+
+    // Show in alphabetical order but with installed games first
+    library.sort((a, b) => {
+      if (a.isInstalled !== b.isInstalled) {
+        return a.isInstalled ? -1 : 1;
+      }
+      return a.title.localeCompare(b.title);
+    });
     
     this.setState({
       user,


### PR DESCRIPTION
Hello, thanks for doing this project! It made sense to me that installed games should show first in the library. _(If I recall correctly that's how the windows launcher does it too)_.

If you don't fancy this, or want it to be configurable only, feel free to close!

## Example: 2 games installed
![](https://user-images.githubusercontent.com/2331607/105103701-ea7d0700-5aa8-11eb-85d5-e0666606619a.jpg)


