### PR TITLE
python3-requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "curl",
         "gconf2",
         "gconf-service",
-        "python-requests",
+        "python3-requests",
         "python-wheel-common",
         "python-setuptools"
       ]


### PR DESCRIPTION
I gave building a shot today and it seems that `python-requests` isn't available anymore, however afaik `python3-requests` should be a drop-in replacement.
 `python-wheel-common` and `python-setuptools` appear to be working fine.

![image](https://user-images.githubusercontent.com/50517631/105498800-82047480-5cb8-11eb-932d-c6e1cd672708.png)
