### PR TITLE
Fix localStorage persist after app close

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,6 +64,7 @@ function createWindow() {
       nodeIntegration: true,
       contextIsolation: false,
       enableRemoteModule: true,
+      partition: 'persist:heroic',
     },
   })
 


### PR DESCRIPTION
Fixes non-persistent localStorage, which caused filter memory to not work.