### PR TITLE
Add Proton GE installation path

### DIFF
--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -41,6 +41,7 @@ const getAlternativeWine = () => {
   const steamPaths: string[] = [
     `${home}/.local/share/Steam`,
     `${home}/.var/app/com.valvesoftware.Steam/.local/share/Steam`,
+    `${home}/.steam/root/compatibilitytools.d`,
     '/usr/share/steam/',
   ]
   const protonPaths: string[] = [`${heroicToolsPath}/proton`]

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -78,6 +78,7 @@ export default function WineSettings({
             <li>.local/share/Steam/steamapps/common</li>
             <li>.local/share/lutris/runners/wine</li>
             <li>.var/app/com.valvesoftware.Steam (Steam Flatpak)</li>
+            <li>.steam/root/compatibilitytools.d</li>
             <li>/usr/share/steam</li>
           </i>
         </ul>


### PR DESCRIPTION
Heroic search for wine version in many path but there aren't the one is recommanded for Proton GE.

~/.steam/root/compatibilitytools.d

Thanks