### PR TITLE
Use local material icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     }
   },
   "dependencies": {
+    "@material-ui/core": "^4.11.3",
+    "@material-ui/icons": "^4.11.2",
     "axios": "^0.21.1",
     "byte-size": "^7.0.0",
     "classnames": "^2.2.6",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"></link>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.gstatic.com">

--- a/src/App.css
+++ b/src/App.css
@@ -1277,10 +1277,10 @@ input:checked + .slider:before {
   color: var(--secondary);
 }
 
-.layoutSelection > span:hover {
+.layoutSelection > svg:hover {
   cursor: pointer;
 }
-.layoutSelection > span {
+.layoutSelection > svg {
   margin: 0 0.2em;
 }
 

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -19,7 +19,8 @@ import '../../App.css'
 import { AppSettings, Game, GameStatus, InstallProgress } from '../../types'
 import ContextProvider from '../../state/ContextProvider'
 import { useParams } from 'react-router-dom'
-import Update from '../UI/Update'
+import Settings from '@material-ui/icons/Settings';
+import UpdateComponent from '../UI/UpdateComponent'
 import GamesSubmenu from './GamesSubmenu'
 import { IpcRenderer, Remote } from 'electron'
 const { ipcRenderer, remote } = window.require('electron') as {
@@ -154,12 +155,11 @@ export default function GamePage() {
         <div className="gameConfigContainer">
           {title ? (
             <>
-              <span
+              <Settings
                 onClick={() => setClicked(!clicked)}
                 className="material-icons is-secondary dots"
               >
-                settings
-              </span>
+              </Settings>
               <GamesSubmenu
                 appName={appName}
                 clicked={clicked}
@@ -267,7 +267,7 @@ export default function GamePage() {
               </div>{' '}
             </>
           ) : (
-            <Update />
+            <UpdateComponent />
           )}
         </div>
       </>

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -158,8 +158,7 @@ export default function GamePage() {
               <Settings
                 onClick={() => setClicked(!clicked)}
                 className="material-icons is-secondary dots"
-              >
-              </Settings>
+              />
               <GamesSubmenu
                 appName={appName}
                 clicked={clicked}

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,6 +1,7 @@
 import React, { lazy, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
+import ArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import ContextProvider from '../state/ContextProvider'
 
 import { Game } from '../types'
@@ -72,7 +73,7 @@ export const Library = ({ library }: Props) => {
         )}
       </div>
       <button id="backToTopBtn" onClick={backToTop}>
-        <span className="material-icons">arrow_drop_up</span>
+        <ArrowDropUp className="material-icons"></ArrowDropUp>
       </button>
     </>
   )

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -73,7 +73,7 @@ export const Library = ({ library }: Props) => {
         )}
       </div>
       <button id="backToTopBtn" onClick={backToTop}>
-        <ArrowDropUp className="material-icons"></ArrowDropUp>
+        <ArrowDropUp className="material-icons" />
       </button>
     </>
   )

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
 import { legendary, loginPage, sidInfoPage } from '../helper'
+import Autorenew from '@material-ui/icons/Autorenew';
+import Info from '@material-ui/icons/Info';
 const storage: Storage = window.localStorage
 interface Props {
   refresh: () => Promise<void>
@@ -76,9 +78,8 @@ export default function Login({ refresh }: Props) {
                 {`${t('message.part4')} `}
                 <span onClick={() => sidInfoPage()} className="sid">
                   {`${t('message.part5')}`}
-                  <i style={{ marginLeft: '4px' }} className="material-icons">
-                    info
-                  </i>
+                  <Info style={{ marginLeft: '4px' }} className="material-icons">
+                  </Info>
                 </span>
                 .
               </li>
@@ -101,7 +102,7 @@ export default function Login({ refresh }: Props) {
             {loading && (
               <p className="message">
                 {message}
-                <span className="material-icons">autorenew</span>{' '}
+                <Autorenew className="material-icons"></Autorenew>{' '}
               </p>
             )}
             <button

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -78,8 +78,7 @@ export default function Login({ refresh }: Props) {
                 {`${t('message.part4')} `}
                 <span onClick={() => sidInfoPage()} className="sid">
                   {`${t('message.part5')}`}
-                  <Info style={{ marginLeft: '4px' }} className="material-icons">
-                  </Info>
+                  <Info style={{ marginLeft: '4px' }} className="material-icons" />
                 </span>
                 .
               </li>
@@ -102,7 +101,7 @@ export default function Login({ refresh }: Props) {
             {loading && (
               <p className="message">
                 {message}
-                <Autorenew className="material-icons"></Autorenew>{' '}
+                <Autorenew className="material-icons" />{' '}
               </p>
             )}
             <button

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -144,8 +144,7 @@ export default function GeneralSettings({
                 setDefaultInstallPath(filePaths[0] ? `'${filePaths[0]}'` : '')
               )
             }
-          >
-          </CreateNewFolder>
+          />
         </span>
       </span>
       <span className="setting">
@@ -176,8 +175,7 @@ export default function GeneralSettings({
                         setEgsPath(filePaths[0] ? `'${filePaths[0]}'` : '')
                       )
               }
-            >
-            </CreateNewFolder>
+            />
           ) : (
             <Backspace
               className="material-icons settings folder"
@@ -187,8 +185,7 @@ export default function GeneralSettings({
                   ? { pointerEvents: 'none', color: 'transparent' }
                   : { color: '#B0ABB6' }
               }
-            >
-            </Backspace>
+            />
           )}
           <button
             onClick={() => handleSync()}

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from '../../state/ContextProvider'
+import CreateNewFolder from '@material-ui/icons/CreateNewFolder';
+import Backspace from '@material-ui/icons/Backspace';
 import { Path } from '../../types'
 import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
@@ -131,7 +133,7 @@ export default function GeneralSettings({
             placeholder={defaultInstallPath}
             onChange={(event) => setDefaultInstallPath(event.target.value)}
           />
-          <span
+          <CreateNewFolder
             className="material-icons settings folder"
             onClick={() =>
               showOpenDialog({
@@ -143,8 +145,7 @@ export default function GeneralSettings({
               )
             }
           >
-            create_new_folder
-          </span>
+          </CreateNewFolder>
         </span>
       </span>
       <span className="setting">
@@ -159,7 +160,7 @@ export default function GeneralSettings({
             onChange={(event) => setEgsPath(event.target.value)}
           />
           {!egsPath.length ? (
-            <span
+            <CreateNewFolder
               className="material-icons settings folder"
               style={{ color: isLinked ? 'transparent' : '#B0ABB6' }}
               onClick={() =>
@@ -176,10 +177,9 @@ export default function GeneralSettings({
                       )
               }
             >
-              create_new_folder
-            </span>
+            </CreateNewFolder>
           ) : (
-            <span
+            <Backspace
               className="material-icons settings folder"
               onClick={() => (isLinked ? '' : setEgsPath(''))}
               style={
@@ -188,8 +188,7 @@ export default function GeneralSettings({
                   : { color: '#B0ABB6' }
               }
             >
-              backspace
-            </span>
+            </Backspace>
           )}
           <button
             onClick={() => handleSync()}

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -104,15 +104,13 @@ export default function SyncSaves({
                         setSavesPath(filePaths[0] ? `${filePaths[0]}` : '')
                       )
               }
-            >
-            </CreateNewFolder>
+            />
           ) : (
             <Backspace
               className="material-icons settings folder"
               onClick={() => setSavesPath('')}
               style={{ color: '#B0ABB6' }}
-            >
-            </Backspace>
+            />
           )}
         </span>
       </span>

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { fixSaveFolder, getGameInfo, syncSaves } from '../../helper'
+import CreateNewFolder from '@material-ui/icons/CreateNewFolder';
+import Backspace from '@material-ui/icons/Backspace';
 import { Path, SyncType } from '../../types'
 import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
@@ -85,7 +87,7 @@ export default function SyncSaves({
             onChange={(event) => setSavesPath(event.target.value)}
           />
           {!savesPath.length ? (
-            <span
+            <CreateNewFolder
               className="material-icons settings folder"
               style={{ color: '#B0ABB6' }}
               onClick={() =>
@@ -103,16 +105,14 @@ export default function SyncSaves({
                       )
               }
             >
-              create_new_folder
-            </span>
+            </CreateNewFolder>
           ) : (
-            <span
+            <Backspace
               className="material-icons settings folder"
               onClick={() => setSavesPath('')}
               style={{ color: '#B0ABB6' }}
             >
-              backspace
-            </span>
+            </Backspace>
           )}
         </span>
       </span>

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { WineProps, Path } from '../../types'
+import CreateNewFolder from '@material-ui/icons/CreateNewFolder';
 import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
 const {
@@ -52,7 +53,7 @@ export default function WineSettings({
             className="settingSelect"
             onChange={(event) => setWinePrefix(event.target.value)}
           />
-          <span
+          <CreateNewFolder
             className="material-icons settings folder"
             onClick={() =>
               dialog
@@ -66,8 +67,7 @@ export default function WineSettings({
                 )
             }
           >
-            create_new_folder
-          </span>
+          </CreateNewFolder>
         </span>
       </span>
       <span className="setting">

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -66,8 +66,7 @@ export default function WineSettings({
                   setWinePrefix(filePaths[0] ? `${filePaths[0]}` : '~/.wine')
                 )
             }
-          >
-          </CreateNewFolder>
+          />
         </span>
       </span>
       <span className="setting">

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
+import ArrowBack from '@material-ui/icons/ArrowBack';
+import Apps from '@material-ui/icons/Apps';
+import List from '@material-ui/icons/List';
 import cx from 'classnames'
 import ContextProvider from '../../state/ContextProvider'
 
@@ -78,7 +81,7 @@ export default function Header({
         {title && <div className="headerTitle">{title}</div>}
         {handleLayout && (
           <div className="layoutSelection">
-            <span
+            <Apps
               className={
                 layout === 'grid'
                   ? 'selectedLayout material-icons'
@@ -86,9 +89,8 @@ export default function Header({
               }
               onClick={() => handleLayout('grid')}
             >
-              apps
-            </span>
-            <span
+            </Apps>
+            <List
               className={
                 layout === 'list'
                   ? 'selectedLayout material-icons'
@@ -96,15 +98,14 @@ export default function Header({
               }
               onClick={() => handleLayout('list')}
             >
-              list
-            </span>
+            </List>
           </div>
         )}
 
         {renderBackButton && (
           <div className="leftCluster">
             <Link className="returnLink" to={link} onClick={handleClick}>
-              <span className="material-icons">arrow_back</span>
+              <ArrowBack className="material-icons"></ArrowBack>
               {t('Return')}
             </Link>
           </div>

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -88,8 +88,7 @@ export default function Header({
                   : 'material-icons'
               }
               onClick={() => handleLayout('grid')}
-            >
-            </Apps>
+            />
             <List
               className={
                 layout === 'list'
@@ -105,7 +104,7 @@ export default function Header({
         {renderBackButton && (
           <div className="leftCluster">
             <Link className="returnLink" to={link} onClick={handleClick}>
-              <ArrowBack className="material-icons"></ArrowBack>
+              <ArrowBack className="material-icons" />
               {t('Return')}
             </Link>
           </div>

--- a/src/components/UI/InfoBox.tsx
+++ b/src/components/UI/InfoBox.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import Info from '@material-ui/icons/Info';
 import { useToggle } from '../../hooks'
 
 interface Props {
@@ -14,7 +15,7 @@ export default function InfoBox({ children }: Props) {
     <>
       <span className="helpLink" onClick={toggleIsHidden}>
         <p>{t('infobox.help')}</p>
-        <i className="material-icons">info</i>
+        <Info className="material-icons"></Info>
       </span>
       <div style={{ display: isHidden ? 'none' : 'block' }} className="infoBox">
         {children}

--- a/src/components/UI/InfoBox.tsx
+++ b/src/components/UI/InfoBox.tsx
@@ -15,7 +15,7 @@ export default function InfoBox({ children }: Props) {
     <>
       <span className="helpLink" onClick={toggleIsHidden}>
         <p>{t('infobox.help')}</p>
-        <Info className="material-icons"></Info>
+        <Info className="material-icons" />
       </span>
       <div style={{ display: isHidden ? 'none' : 'block' }} className="infoBox">
         {children}

--- a/src/components/UI/SearchBar.tsx
+++ b/src/components/UI/SearchBar.tsx
@@ -11,8 +11,8 @@ export default function SearchBar() {
 
   return (
     <div className="SearchBar">
-      <label htmlFor="search"><Search onClick={() => handleSearch(textValue)} className="material-icons">
-      </Search>
+      <label htmlFor="search">
+        <Search onClick={() => handleSearch(textValue)} className="material-icons" />
       </label>
       <input
         className="searchInput"
@@ -32,8 +32,7 @@ export default function SearchBar() {
             handleSearch('')
           }}
           className="material-icons close"
-        >
-        </Close>
+        />
       )}
     </div>
   )

--- a/src/components/UI/SearchBar.tsx
+++ b/src/components/UI/SearchBar.tsx
@@ -1,5 +1,7 @@
 import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import Search from '@material-ui/icons/Search';
+import Close from '@material-ui/icons/Close';
 import ContextProvider from '../../state/ContextProvider'
 
 export default function SearchBar() {
@@ -9,9 +11,8 @@ export default function SearchBar() {
 
   return (
     <div className="SearchBar">
-      <label htmlFor="search"><span onClick={() => handleSearch(textValue)} className="material-icons">
-          search
-      </span>
+      <label htmlFor="search"><Search onClick={() => handleSearch(textValue)} className="material-icons">
+      </Search>
       </label>
       <input
         className="searchInput"
@@ -25,15 +26,14 @@ export default function SearchBar() {
         />
        
       {textValue.length > 0 && (
-        <span
+        <Close
           onClick={() => {
             setTextValue('')
             handleSearch('')
           }}
           className="material-icons close"
         >
-          close
-        </span>
+        </Close>
       )}
     </div>
   )

--- a/src/components/UI/Update.tsx
+++ b/src/components/UI/Update.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-export default function Update() {
-  return (
-    <div className="updateIcon">
-      <span className="material-icons">update</span>
-    </div>
-  )
-}

--- a/src/components/UI/UpdateComponent.tsx
+++ b/src/components/UI/UpdateComponent.tsx
@@ -4,7 +4,7 @@ import Update from '@material-ui/icons/Update';
 export default function UpdateComponent() {
   return (
     <div className="updateIcon">
-      <Update className="material-icons"></Update>
+      <Update className="material-icons" />
     </div>
   )
 }

--- a/src/components/UI/UpdateComponent.tsx
+++ b/src/components/UI/UpdateComponent.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Update from '@material-ui/icons/Update';
+
+export default function UpdateComponent() {
+  return (
+    <div className="updateIcon">
+      <Update className="material-icons"></Update>
+    </div>
+  )
+}

--- a/src/components/UI/UserSelector.tsx
+++ b/src/components/UI/UserSelector.tsx
@@ -25,7 +25,7 @@ export default function UserSelector() {
     <div className="UserSelector">
       <span className="userName">
         {user}
-        <ArrowDropDown className="material-icons"></ArrowDropDown>
+        <ArrowDropDown className="material-icons" />
       </span>
       <div onClick={() => refreshLibrary()} className="userName hidden">
         {t('userselector.refresh')}

--- a/src/components/UI/UserSelector.tsx
+++ b/src/components/UI/UserSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import {
   legendary,
   openAboutWindow,
@@ -24,7 +25,7 @@ export default function UserSelector() {
     <div className="UserSelector">
       <span className="userName">
         {user}
-        <span className="material-icons">arrow_drop_down</span>
+        <ArrowDropDown className="material-icons"></ArrowDropDown>
       </span>
       <div onClick={() => refreshLibrary()} className="userName hidden">
         {t('userselector.refresh')}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import './index.css'
 import App from './App'
 import GlobalState from './state/GlobalState'
-import Update from './components/UI/Update'
+import UpdateComponent from './components/UI/UpdateComponent'
 
 const Backend = new HttpApi(null, {
   allowMultiLoading: false,
@@ -39,7 +39,7 @@ i18next
 ReactDOM.render(
   <React.StrictMode>
     <I18nextProvider i18n={i18next}>
-      <Suspense fallback={<Update />}>
+      <Suspense fallback={<UpdateComponent />}>
         <GlobalState>
           <App />
         </GlobalState>

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -2,7 +2,7 @@ import { IpcRenderer } from 'electron'
 import { i18n } from 'i18next'
 import React, { PureComponent } from 'react'
 import { TFunction, withTranslation } from 'react-i18next'
-import Update from '../components/UI/Update'
+import UpdateComponent from '../components/UI/UpdateComponent'
 import {
   getGameInfo,
   getLegendaryConfig,
@@ -258,7 +258,7 @@ export class GlobalState extends PureComponent<Props> {
     const { data, filterText, filter, refreshing } = this.state
 
     if (refreshing) {
-      return <Update />
+      return <UpdateComponent />
     }
 
     const filterRegex = new RegExp(String(filterText), 'i')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+  version "7.12.18"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.18.tgz#af137bd7e7d9705a412b3caaf991fe6aaa97831b"
+  integrity sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1182,6 +1189,11 @@
   optionalDependencies:
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -1417,6 +1429,77 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@material-ui/core@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
+  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.3"
+    "@material-ui/system" "^4.11.3"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
+"@material-ui/styles@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
+  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.5.1"
+    jss-plugin-camel-case "^10.5.1"
+    jss-plugin-default-unit "^10.5.1"
+    jss-plugin-global "^10.5.1"
+    jss-plugin-nested "^10.5.1"
+    jss-plugin-props-sort "^10.5.1"
+    jss-plugin-rule-value-function "^10.5.1"
+    jss-plugin-vendor-prefixer "^10.5.1"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
+  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -1876,6 +1959,13 @@
   integrity sha512-ofHbZMlp0Y2baOHgsWBQ4K3AttxY61bDMkwTiBOkPg7U6C/3UwwB5WaIx28JmSVi/eX3uFEMRo61BV22fDQIvg==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
+  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
+  dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17.0.0":
@@ -3595,6 +3685,11 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4087,6 +4182,14 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
@@ -4227,6 +4330,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^2.5.2:
+  version "2.6.15"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.15.tgz#655901663db1d652f10cb57ac6af5a05972aea1f"
+  integrity sha512-FNeiVKudquehtR3t9TRRnsHL+lJhuHF5Zn9dt01jpojlurLEPDhhEtUkWmAUJ7/fOLaLG4dCDEnUsR0N1rZSsg==
 
 csstype@^3.0.2:
   version "3.0.6"
@@ -4529,6 +4637,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -6160,7 +6276,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6384,6 +6500,11 @@ husky@^4.3.8:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 i18next-browser-languagedetector@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.0.1.tgz#83654bc87302be2a6a5a75146ffea97b4ca268cf"
@@ -6545,6 +6666,13 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite-observable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-2.0.1.tgz#574af29bfbc17eb5947793797bddc94c9d859400"
+  integrity sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==
+  dependencies:
+    symbol-observable "1.2.0"
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -6817,6 +6945,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-installed-globally@^0.3.1:
   version "0.3.2"
@@ -7679,6 +7812,77 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz#427b24a9951b4c2eaa7e3d5267acd2e00b0934f9"
+  integrity sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.5.1"
+
+jss-plugin-default-unit@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz#2be385d71d50aee2ee81c2a9ac70e00592ed861b"
+  integrity sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-global@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz#0e1793dea86c298360a7e2004721351653c7e764"
+  integrity sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-nested@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz#8753a80ad31190fb6ac6fdd39f57352dcf1295bb"
+  integrity sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz#ab1c167fd2d4506fb6a1c1d66c5f3ef545ff1cd8"
+  integrity sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-rule-value-function@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz#37f4030523fb3032c8801fab48c36c373004de7e"
+  integrity sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz#45a183a3a0eb097bdfab0986b858d99920c0bbd8"
+  integrity sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.5.1"
+
+jss@10.5.1, jss@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.5.1.tgz#93e6b2428c840408372d8b548c3f3c60fa601c40"
+  integrity sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    indefinite-observable "^2.0.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
@@ -9172,6 +9376,11 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -10218,7 +10427,7 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
@@ -10322,6 +10531,16 @@ react-scripts@4.0.1:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^17.0.1:
   version "17.0.1"
@@ -11718,6 +11937,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -11895,7 +12119,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
I had to rename `Update` to `UpdateComponent` because of a name conflict.
I wanted to import it as a different name but it didn't work with `import Update as UpdateIcon from ...`
(fixes #174)

Google Fonts removed in #181

I don't know how adding those two npm packages affect the build size. I hope it uses treeshaking.