### PR TITLE
Fix translation generation

### DIFF
--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -73,6 +73,14 @@
       "message": "Chesz spróbować naprawć tą grę? To może zająć dużo czasu.",
       "title": "Sprawdź i napraw"
     },
+    "saves": {
+      "syncing": "Synchronizacja zapisów gry"
+    },
+
+    "playing": {
+      "start": "Graj",
+      "stop": "Gra włączona (Zatrzymaj)"
+    },
     "stopInstall": {
       "keepInstalling": "Kontunuuj instalację",
       "message": "Czy chcesz zachować pobrane pliki?",
@@ -87,54 +95,6 @@
       "title": "Gra Potrzebuje Aktualizacji"
     },
     "yes": "TAK"
-  },
-  "button": {
-    "cancel": "Anuluj",
-    "import": "Importuj",
-    "install": "Instaluj",
-    "uninstall": "Usuń"
-  },
-  "disabled": "Wyłączona",
-  "enabled": "Włączona",
-  "gamecard": {
-    "moving": "Moving",
-    "repairing": "Repairing"
-  },
-  "info": {
-    "path": "Ścieżka instalacyjna",
-    "size": "Rozmiar",
-    "syncsaves": "Synchronizuj zapisy gry",
-    "version": "Wersja"
-  },
-  "install": {
-    "another": "Instaluj w innej ścieżką",
-    "default": "Instaluj w domyślnej ścieżce",
-    "import": "Importuj grę"
-  },
-  "label": {
-    "cancel": {
-      "update": "Anuluj aktualizację"
-    },
-
-    "playing": {
-      "start": "Graj",
-      "stop": "Gra włączona (Zatrzymaj)"
-    },
-    "saves": {
-      "syncing": "Synchronizacja zapisów gry"
-    "submenu": {
-        "log": "Ostatni log",
-        "move": "Przenieś grę",
-        "protondb": "Sprawdź kompatybilność",
-        "settings": "Ustawienia",
-        "store": "Strona sklepu",
-        "verify": "Sprawdź i napraw"
-    },
-    "specs": {
-        "minimum": "Minimalne",
-        "recommended": "Rekomendowane"
-
-    }
   },
   "status": {
     "installed": "Zainstalowane",
@@ -152,5 +112,9 @@
     "settings": "Ustawienia",
     "store": "Strona sklepu",
     "verify": "Sprawdź i napraw"
+  },
+  "specs": {
+    "minimum": "Minimalne",
+    "recommended": "Rekomendowane"
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -31,9 +31,6 @@
       "button": "Wybierz",
       "error": "Nieprawidłowa ścieżka",
       "title": "Wybierz folder zapisów gry"
-    "infobox": {
-        "help": "Pomoc",
-        "requirements": "Wymagania"
     },
     "wineprefix": "Wybierz folder prefiksu Wine",
     "yes": "TAK"
@@ -72,7 +69,8 @@
     "settings": "Ustawienia są zapisywane automatycznie"
   },
   "infobox": {
-    "help": "Pomoc"
+    "help": "Pomoc",
+    "requirements": "Wymagania"
   },
   "Library": "Biblioteka",
   "message": {

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -85,8 +85,8 @@
     "store": "Mağaza Sayfası",
     "verify": "Doğrula ve Onar"
   },
-  "specs": {​
-    "minimum"​: ​ "Minimum"​,
-    ​​"recommended"​: ​ "Önerilen"
+  "specs": {
+    "minimum": "Minimum",
+    "recommended": "Önerilen"
   }
 }

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -69,8 +69,8 @@
     "settings": "Ayarlar otomatik kaydedilir"
   },
   "infobox": {
-    "help": "Yardım",​
-    "requirements"​: ​"Sistem Gereksinimleri"​
+    "help": "Yardım",
+    "requirements": "Sistem Gereksinimleri"
   },
   "Library": "Kütüphane",
   "message": {


### PR DESCRIPTION
Fixed the Polish and Turkish locale JSON's.
The Polish JSON was fully formatted, this probably happened with a merge, and are easily overlooked.
The Turkish document had weird characters, this can be prevented to copy text from the web. Into a text editor like gedit or alike. and then copy that, to past it in to the document.